### PR TITLE
fix: Resolve Windows installation errors for tgcrypto and xattr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,9 @@ python-magic
 requests
 telegraph
 tenacity
-tgcrypto
+pytgcrypto
 urllib3
 uvicorn
 uvloop; sys_platform != "win32"
-xattr
+xattr; sys_platform != "win32"
 yt-dlp[default,curl-cffi]


### PR DESCRIPTION
This commit resolves build failures on Windows for the `tgcrypto` and `xattr` packages.

- Replaces the `tgcrypto` package with `pytgcrypto`. `pytgcrypto` is a drop-in replacement that provides pre-compiled binary wheels for Windows, removing the need for the Microsoft C++ Build Tools.
- Marks the `xattr` package as a conditional dependency, to be installed only on non-Windows platforms (`sys_platform != 'win32'`), as it is a POSIX-only library.