### PR TITLE
When the JDownloader API returns an empty or invalid (non-JSON) respo…

### DIFF
--- a/myjd/myjdapi.py
+++ b/myjd/myjdapi.py
@@ -756,7 +756,7 @@ class MyJdApi:
             response = res.json()
         except JSONDecodeError as exc:
             raise MYJDDecodeException(
-                "Failed to decode response: {}", response
+                f"Failed to decode response: {res.text}"
             ) from exc
         if res.status_code != 200:
             msg = (


### PR DESCRIPTION
…nse, the `res.json()` call in `myjd/myjdapi.py` raises a `JSONDecodeError`.

The `except` block that handled this error was trying to log the `response` variable, which was never assigned, causing a subsequent `UnboundLocalError` and crashing the thread.

This commit fixes the `except` block to log the raw `res.text` instead. This prevents the `UnboundLocalError` and provides better debugging information when the JDownloader API misbehaves.