### PR TITLE
I was crashing on startup with an `ImportError` because the `bot.help…

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -53,6 +53,7 @@ queued_dl = {}
 queued_up = {}
 status_dict = {}
 task_dict = {}
+VID_MODE = {'merge_rmaudio': 'Merge/Remove Audio'}
 rss_dict = {}
 auth_chats = {}
 excluded_extensions = ["aria2", "!qB"]


### PR DESCRIPTION
…er.video_utils.executor` module was trying to import the `VID_MODE` variable from the top-level `bot` package, but it was not defined there.

This commit fixes the crash by defining the `VID_MODE` dictionary in `bot/__init__.py`. This makes the variable available for import and allows the video processing modules to load correctly.