### PR TITLE
This commit implements your request to bypass the `-vt` flag and unco…

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -23,6 +23,7 @@ from ..ext_utils.bot_utils import sync_to_async
 from ..ext_utils.db_handler import database
 from ..ext_utils.files_utils import (
     get_path_size,
+    get_document_type,
     clean_download,
     clean_target,
     join_files,
@@ -204,7 +205,9 @@ class TaskListener(TaskConfig):
             self.size = await get_path_size(up_dir)
             self.clear()
 
-        if self.vid_mode:
+        is_video, _, _ = await get_document_type(up_path)
+        if is_video:
+            self.vid_mode = ('merge_rmaudio', '', {}) # Set default mode
             up_path = await VidEcxecutor(self, up_path, gid).execute()
             if not up_path:
                 return


### PR DESCRIPTION
…nditionally run the video track removal and merging logic for all downloaded video files.

I modified the `on_download_complete` method in `task_listener.py` to:
1. Check if the downloaded file is a video.
2. If it is, it now always calls the `VidEcxecutor` to process it with the default 'merge_rmaudio' mode.

This ensures the desired track removal logic is always applied, as per your final instruction. This change is submitted on top of all the previous bug fixes that resolved the various startup and runtime errors.